### PR TITLE
fix the nix shell/build

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+dotenv_if_exists
+watch_file build.nix
+watch_file shell.nix
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+result
+*.swp
+/.direnv
 /target/
 /.idea/

--- a/build.nix
+++ b/build.nix
@@ -1,0 +1,48 @@
+{ lib
+, rustPlatform
+, pkg-config
+, alsa-lib
+, libudev-zero
+, libX11
+, libXcursor
+, libXrandr
+, libXi
+, libGL
+, vulkan-loader
+, makeWrapper
+}:
+rustPlatform.buildRustPackage {
+  pname = "rust-tetris";
+  version = "0.1.0";
+
+  src = ./.;
+
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
+
+  buildInputs = [
+    alsa-lib
+    libudev-zero
+    libX11
+    libXcursor
+    libXrandr
+    libXi
+  ];
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  # Make sure that our program knows where to find graphics libraries at
+  # runtime.
+  postInstall = ''
+    wrapProgram $out/bin/rust-tetris \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath[
+        "/run/opengl-driver"
+        "/run/opengl-driver-32"
+        libGL
+        vulkan-loader
+      ]}"
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1705566941,
+        "narHash": "sha256-CLNtVRDA8eUPk+bxsCCZtRO0Cp+SpHdn1nNOLoFypLs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b06ff4bf8f4ad900fe0c2a61fc2946edc3a84be7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem
+    (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+      rec {
+        packages.default = pkgs.callPackage ./build.nix { };
+        devShells.default = pkgs.callPackage ./shell.nix {
+          rust-tetris = packages.default;
+        };
+      }
+    );
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,27 @@
-{ pkgs ? import <nixpkgs> { } }:
-
-pkgs.mkShell
+{ pkgs ? import <nixpkgs> { }
+, rust-tetris ? pkgs.callPackage ./build.nix { }
+}:
+with pkgs;
+mkShell
 {
-    nativeBuildInputs = [
-        pkgs.pkg-config
-        pkgs.libudev-zero
-        pkgs.alsa-lib
+  # Pull in everything needed to build our crate.
+  inputsFrom = [ rust-tetris ];
 
-    ];
+  # Other development niceties.
+  RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
+  packages = with pkgs; [
+    rust-analyzer
+    clippy
+  ];
+
+  # Make sure the graphics libraries are findable in our dev shell.
+  shellHook = ''
+    export LD_LIBRARY_PATH="${lib.makeLibraryPath [
+      "/run/opengl-driver"
+      "/run/opengl-driver-32"
+      libGL
+      vulkan-loader
+    ]}:$LD_LIBRARY_PATH"
+  '';
 }
 


### PR DESCRIPTION
A number of improvements:

* Add a nix flake, which improves reproducibility
* Add direnv, which can be used to automatically get dev tools in your shell or IDE with the proper plugin
* Add a dedicated `build.nix` in `callPackage` format that fully specifies the dependencies needed to build and run
* Pull the build inputs into `shell.nix` via `inputsFrom`, and add other development-only tools such as rust-analyzer and clippy.
